### PR TITLE
fix(Button): remove no needed boolean check for btnType classname

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -28,8 +28,8 @@ const Button: React.FC<ButtonProps> = (props) => {
   } = props;
   const classes = classNames(
     "btn",
+    `btn-${btnType}`,
     {
-      [`btn-${btnType}`]: btnType,
       [`btn-${size}`]: size,
       [`btn-disabled`]: btnType === "link" && disabled,
     },


### PR DESCRIPTION
# Why?

`btnType` has a default value, so no need to have the "boolean" check for it.

# How?

remove the boolean check and move it into the default className
