### PR TITLE
fix(storyBook): add icon in storyBook

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,9 +1,13 @@
 import React, { Fragment } from "react";
 import { configure, addDecorator, addParameters } from "@storybook/react";
 import { withInfo } from "@storybook/addon-info";
-
 import "../src/styles/index.scss";
 import "./fix_info_style.scss";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { fas } from "@fortawesome/free-solid-svg-icons";
+import "../src/styles/index.scss";
+
+library.add(fas);
 
 const wrapperStyle: React.CSSProperties = {
   padding: "20px 40px",


### PR DESCRIPTION
# Why?

The icon is not showing in storyBook

# How?

Import the `FontAwesome` in storyBook general setting
