### PR TITLE
fix(npm): modify package.json, add peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,24 +21,13 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.29",
     "@fortawesome/free-solid-svg-icons": "^5.13.1",
     "@fortawesome/react-fontawesome": "^0.1.11",
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
-    "@types/classnames": "^2.2.10",
-    "@types/jest": "^24.0.0",
-    "@types/node": "^12.0.0",
-    "@types/react": "^16.9.0",
-    "@types/react-dom": "^16.9.0",
-    "@types/react-transition-group": "^4.4.0",
-    "@types/storybook__addon-info": "^5.2.1",
     "axios": "^0.20.0",
     "classnames": "^2.2.6",
-    "node-sass": "^4.14.1",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
-    "react-scripts": "3.4.1",
-    "react-transition-group": "^4.4.1",
-    "typescript": "~3.7.2"
+    "react-transition-group": "^4.4.1"
+  },
+  "peerDependencies":{
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "scripts": {
     "start": "PORT=3006 react-scripts start",
@@ -68,6 +57,16 @@
     ]
   },
   "devDependencies": {
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "node-sass": "^4.14.1",
+    "@types/classnames": "^2.2.10",
+    "@types/jest": "^24.0.0",
+    "@types/node": "^12.0.0",
+    "@types/react": "^16.9.0",
+    "@types/react-dom": "^16.9.0",
+    "@types/react-transition-group": "^4.4.0",
+    "@types/storybook__addon-info": "^5.2.1",
     "@storybook/addon-actions": "^5.3.18",
     "@storybook/addon-info": "^5.3.18",
     "@storybook/addon-links": "^5.3.18",
@@ -75,6 +74,11 @@
     "@storybook/preset-create-react-app": "^2.1.2",
     "@storybook/react": "^5.3.18",
     "react-docgen-typescript-loader": "^3.7.2",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "react-scripts": "3.4.1",
+    "typescript": "~3.7.2",
+    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/react": "^9.3.2",
+    "@testing-library/user-event": "^7.1.2"
   }
 }


### PR DESCRIPTION
# Why?

1. Too many dependencies need to be installed when installing
2. Have bug reported when use library in another project: have mismatching versions of React and the renderer (such as React DOM)

# How?

1. Move all only dev needed dependencies into `devDependencies` 
2. Add `peerDependencies` for `react & `react-dom` version limitations, and move these 2 dependencies into `devDependencies` for local development usage only 
