### PR TITLE
doc(Button): fix the wrong props description order

### DIFF
--- a/src/components/AutoComplete/autoComplete.stories.tsx
+++ b/src/components/AutoComplete/autoComplete.stories.tsx
@@ -15,18 +15,18 @@ interface GithubUserProps {
 }
 const simpleComplete = () => {
   const lakers = [
-    "bradley",
-    "pope",
-    "caruso",
-    "cook",
-    "cousins",
-    "james",
+    "Bradley",
+    "Pope",
+    "Caruso",
+    "Cook",
+    "Cousins",
+    "James",
     "AD",
-    "green",
-    "howard",
-    "kuzma",
+    "Green",
+    "Howard",
+    "Kuzma",
     "McGee",
-    "rando",
+    "Rando",
   ];
   const handleFetch = (query: string) => {
     return lakers
@@ -46,18 +46,18 @@ const textComplete = `
 ### Code sample
 ~~~javascript
 const lakers = [
-    "bradley",
-    "pope",
-    "caruso",
-    "cook",
-    "cousins",
-    "james",
+    "Bradley",
+    "Pope",
+    "Caruso",
+    "Cook",
+    "Cousins",
+    "James",
     "AD",
-    "green",
-    "howard",
-    "kuzma",
+    "Green",
+    "Howard",
+    "Kuzma",
     "McGee",
-    "rando",
+    "Rando",
   ];
   const handleFetch = (query: string) => {
     return lakers

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -5,15 +5,15 @@ export type ButtonType = "primary" | "danger" | "link" | "default";
 export type ButtonSize = "lg" | "sm";
 
 interface BaseButtonProps {
-  /** can be set to primary ghost dashed link or default */
+  /** Different types */
   btnType?: ButtonType;
-  /** add customized className for button */
+  /** set the size of button */
   size?: ButtonSize;
-  /** redirect url of link button */
+  /** add customized className for button */
   className?: string;
   /** disabled state of button */
   disabled?: boolean;
-  /** set the size of button */
+  /** redirect url of link button */
   href?: string;
   children: React.ReactNode;
 }


### PR DESCRIPTION
# Why?

There have some problems for the storybook
- the `Button` props description have wrong order
- In `autoComplete` component's example: "Simple Complete", the names should be start with the capital letter

# How?

fix them